### PR TITLE
Add apline package libffi-dev to fix build error

### DIFF
--- a/parsedmarc/Dockerfile
+++ b/parsedmarc/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:alpine
 
-RUN apk add build-base libxml2-dev libxslt-dev \
+RUN apk add build-base libffi-dev libxml2-dev libxslt-dev \
     && pip install parsedmarc
 
 COPY parsedmarc.ini /


### PR DESCRIPTION
This pull request fixed error that prevents dmarc-visualiser from build when `docker-compose up` is run.   

Another user suggested this fix https://github.com/debricked/dmarc-visualizer/issues/28

```
  Running setup.py clean for cffi
Successfully built expiringdict maxminddb
Failed to build cffi
Installing collected packages: pytz, pyasn1, publicsuffix2, kafka-python, expiringdict, certifi, xmltodict, urllib3, uritemplate, tzdata, typing-extensions, tqdm, six, simplejson, rsa, regex, pyparsing, PyJWT, pycparser, pyasn1-modules, protobuf, portalocker, oauthlib, multidict, msgraph-core, maxminddb, lxml, jmespath, idna, html2text, frozenlist, dnspython, charset-normalizer, cachetools, attrs, async-timeout, yarl, requests, pytz-deprecation-shim, python-dateutil, mail-parser, imapclient, httplib2, googleapis-common-protos, google-auth, elasticsearch, cffi, aiosignal, tzlocal, requests-oauthlib, mailsuite, google-auth-httplib2, google-api-core, elasticsearch-dsl, cryptography, botocore, azure-core, aiohttp, s3transfer, google-auth-oauthlib, google-api-python-client, geoip2, dateparser, msal, boto3, msal-extensions, azure-identity, parsedmarc
  Running setup.py install for cffi: started
  Running setup.py install for cffi: finished with status 'error'
  error: subprocess-exited-with-error
  
  × Running setup.py install for cffi did not run successfully.
  │ exit code: 1
  ╰─> [56 lines of output]
      Package libffi was not found in the pkg-config search path.
      Perhaps you should add the directory containing `libffi.pc'
      to the PKG_CONFIG_PATH environment variable
      Package 'libffi', required by 'virtual:world', not found
      Package libffi was not found in the pkg-config search path.
      Perhaps you should add the directory containing `libffi.pc'
      to the PKG_CONFIG_PATH environment variable
      Package 'libffi', required by 'virtual:world', not found
      Package libffi was not found in the pkg-config search path.
      Perhaps you should add the directory containing `libffi.pc'
      to the PKG_CONFIG_PATH environment variable
      Package 'libffi', required by 'virtual:world', not found
      Package libffi was not found in the pkg-config search path.
      Perhaps you should add the directory containing `libffi.pc'
      to the PKG_CONFIG_PATH environment variable
      Package 'libffi', required by 'virtual:world', not found
      Package libffi was not found in the pkg-config search path.
      Perhaps you should add the directory containing `libffi.pc'
      to the PKG_CONFIG_PATH environment variable
      Package 'libffi', required by 'virtual:world', not found
      running install
      running build
      running build_py
      creating build
      creating build/lib.linux-x86_64-3.10
      creating build/lib.linux-x86_64-3.10/cffi
      copying cffi/ffiplatform.py -> build/lib.linux-x86_64-3.10/cffi
      copying cffi/api.py -> build/lib.linux-x86_64-3.10/cffi
      copying cffi/vengine_gen.py -> build/lib.linux-x86_64-3.10/cffi
      copying cffi/vengine_cpy.py -> build/lib.linux-x86_64-3.10/cffi
      copying cffi/recompiler.py -> build/lib.linux-x86_64-3.10/cffi
      copying cffi/error.py -> build/lib.linux-x86_64-3.10/cffi
      copying cffi/cffi_opcode.py -> build/lib.linux-x86_64-3.10/cffi
      copying cffi/setuptools_ext.py -> build/lib.linux-x86_64-3.10/cffi
      copying cffi/cparser.py -> build/lib.linux-x86_64-3.10/cffi
      copying cffi/model.py -> build/lib.linux-x86_64-3.10/cffi
      copying cffi/commontypes.py -> build/lib.linux-x86_64-3.10/cffi
      copying cffi/__init__.py -> build/lib.linux-x86_64-3.10/cffi
      copying cffi/backend_ctypes.py -> build/lib.linux-x86_64-3.10/cffi
      copying cffi/verifier.py -> build/lib.linux-x86_64-3.10/cffi
      copying cffi/pkgconfig.py -> build/lib.linux-x86_64-3.10/cffi
      copying cffi/lock.py -> build/lib.linux-x86_64-3.10/cffi
      copying cffi/_cffi_include.h -> build/lib.linux-x86_64-3.10/cffi
      copying cffi/parse_c_type.h -> build/lib.linux-x86_64-3.10/cffi
      copying cffi/_embedding.h -> build/lib.linux-x86_64-3.10/cffi
      copying cffi/_cffi_errors.h -> build/lib.linux-x86_64-3.10/cffi
      running build_ext
      building '_cffi_backend' extension
      creating build/temp.linux-x86_64-3.10
      creating build/temp.linux-x86_64-3.10/c
      gcc -Wno-unused-result -Wsign-compare -DNDEBUG -g -fwrapv -O3 -Wall -DTHREAD_STACK_SIZE=0x100000 -fPIC -DUSE__THREAD -DHAVE_SYNC_SYNCHRONIZE -I/usr/include/ffi -I/usr/include/libffi -I/usr/local/include/python3.10 -c c/_cffi_backend.c -o build/temp.linux-x86_64-3.10/c/_cffi_backend.o
      c/_cffi_backend.c:15:10: fatal error: ffi.h: No such file or directory
         15 | #include <ffi.h>
            |          ^~~~~~~
      compilation terminated.
      error: command '/usr/bin/gcc' failed with exit code 1
      [end of output]
  
  note: This error originates from a subprocess, and is likely not a problem with pip.
error: legacy-install-failure

× Encountered error while trying to install package.
╰─> cffi

note: This is an issue with the package mentioned above, not pip.
hint: See above for output from the failure.
ERROR: Service 'parsedmarc' failed to build: The command '/bin/sh -c apk add build-base libxml2-dev libxslt-dev     && pip install parsedmarc' returned a non-zero code: 1
```

