### PR TITLE
Add verbose and volume for ES

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,19 +1,24 @@
 version: '3.5'
+volumes:
+  elastic_data: {}
+
 services:
   parsedmarc:
     build: ./parsedmarc/
     volumes:
       - ./files:/input:ro
       - ./output_files:/output
-    command: parsedmarc -c /parsedmarc.ini /input/*
+    command: parsedmarc --verbose -c /parsedmarc.ini /input/*
     depends_on:
       - elasticsearch
     restart: on-failure
 
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:7.9.1
+    image: docker.elastic.co/elasticsearch/elasticsearch:7.17.5
     environment:
       - discovery.type=single-node
+    volumes:
+      - elastic_data:/usr/share/elasticsearch/data
 
   grafana:
     build: ./grafana/


### PR DESCRIPTION
- add verbose flag so progress is shown during long `parsedmarc` process
- add named volume on the ElasticSearch container so you can persist the data and come back to it